### PR TITLE
For pull requests, get the source branch name from github

### DIFF
--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -9,11 +9,12 @@ sudo add-apt-repository -y ppa:hvr/ghc\
 	 echo "Installing Ubuntu packages: $UBUNTU_PKGS"
 	 sudo apt-get install $UBUNTU_PKGS
      fi\
+  && HEAD_BRANCH=$(python travis/scripts/head_branch.py)
   && for DEP in $HEAD_DEPS
      do
        echo "Cloning $DEP from github..."
        git clone --quiet git://github.com/diagrams/$DEP.git
        cd $DEP
-       if git branch -a |grep -x "  remotes/origin/${TRAVIS_BRANCH}" > /dev/null; then git checkout ${TRAVIS_BRANCH}; fi
+       if git branch -a |grep -x "  remotes/origin/${HEAD_BRANCH}" > /dev/null; then git checkout ${HEAD_BRANCH}; fi
        cd ..
      done

--- a/scripts/head_branch.py
+++ b/scripts/head_branch.py
@@ -1,0 +1,19 @@
+import json
+import sys
+import urllib
+import os
+
+if os.environ['TRAVIS_PULL_REQUEST']=='false':
+    # For non-pull-request commits, Travis knows the branch name
+    print(os.environ['TRAVIS_BRANCH'])
+else:
+    # If this is a pull request, get the name of the HEAD (source)
+    # branch from github
+    url = "https://api.github.com/repos/{0}/pulls/{1}".format(
+        os.environ['TRAVIS_REPO_SLUG'],
+        os.environ['TRAVIS_PULL_REQUEST'] )
+    req = urllib.urlopen(url)
+    j = json.load(req)
+    # should we check here that the head is actually from the same
+    # repo, not a fork?
+    print(j['head']['ref'])


### PR DESCRIPTION
This python script does the right thing testing on my computer.  I haven't tested it on travis, for obvious reasons.  For example, if travis python is actually python 3, it won't work.

Following @byorgey's suggestion on IRC:

```
<byorgey> so, our travis stuff does the right thing when building branch X
          that depends on branch X from another repo (it looks for a branch of
          the same name)  [22:12]
<byorgey> but it looks like it doesn't do the right thing for pull requests
<byorgey> because when building a pull request it thinks it is building the
          branch being merged into rather than the branch being merged from
                                                                        [22:13]
<byorgey> so it checks out the wrong branch of the dependencies.
<fryguybob> byorgey: Ah, bummer.  [22:17]
<bergey> byorgey: Yes, I remember running into that with the lens branches.
<byorgey> we can find out from travis if we are building a pull request (with
          the TRAVIS_PULL_REQUEST env var)  [22:18]
<byorgey> then we could use the github API to find out the name of the branch
          the PR originated from.
<byorgey> seems like a lot of work, but this probably won't be the last time
          this situation comes up  [22:19]
```
