### PR TITLE
bump caba-install version

### DIFF
--- a/.travis.yml.template
+++ b/.travis.yml.template
@@ -8,7 +8,7 @@ env:
     - GHCVER=7.6.3
     - GHCVER=head
   global:
-    - CABALVER=1.18
+    - CABALVER=1.20
     - UBUNTU_PKGS=""
     - EXTRA_DEPS_PRE=""
     - HEAD_DEPS=""


### PR DESCRIPTION
cabal install 1.20.1 has some bug fixes to how build plans work that will resolve certain problems in build plan selection
