### PR TITLE
use cabal sandbox for travis builds, HEAD_DEPS

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -4,6 +4,7 @@ $CABAL update\
        then
          $CABAL install $CABAL_CONSTRAINTS haddock -j$NUM_CPU
      fi\
+  && $CABAL sandbox init\
   && if ! [[ -z "$EXTRA_DEPS_PRE" ]]
        then
          echo "============================================================"
@@ -16,24 +17,16 @@ $CABAL update\
   && if ! [[ -z "$HEAD_DEPS" ]]
        then
          echo "============================================================"
-         echo "Installing HEAD dependencies: $HEAD_DEPS"
-         for DEP in $HEAD_DEPS
-         do
-           DIRS="$DIRS $DEP/"
-         done
+         echo "Registering HEAD dependencies: $HEAD_DEPS"
+         ADD_SOURCE="$CABAL sandbox add-source $HEAD_DEPS"
+         echo $ADD_SOURCE
+         $ADD_SOURCE
      fi\
-  && echo "Installing dependencies from Hackage"\
-   && DEPS_INSTALL="$CABAL install  --enable-tests --enable-benchmarks --only-dependencies $DIRS . $CABAL_CONSTRAINTS -j$NUM_CPU"\
-   && echo $DEPS_INSTALL\
-   && $DEPS_INSTALL --dry-run -v3\
-   && $DEPS_INSTALL\
-   && if ! [[ -z "DIRS" ]]
-       then
-       echo "Installing $HEAD_DEPS"
-       HEAD_DEPS_INSTALL="$CABAL install $DIRS $CABAL_CONSTRAINTS -j$NUM_CPU"
-       echo $HEAD_DEPS_INSTALL
-       $HEAD_DEPS_INSTALL
-   fi\
+  && echo "Installing dependencies"\
+  && DEPS_INSTALL="$CABAL install  --enable-tests --enable-benchmarks --only-dependencies  $CABAL_CONSTRAINTS -j$NUM_CPU"\
+  && echo $DEPS_INSTALL\
+  && $DEPS_INSTALL --dry-run -v3\
+  && $DEPS_INSTALL\
   && if ! [[ -z "$EXTRA_DEPS" ]]
        then
          echo "============================================================"


### PR DESCRIPTION
This avoids a number of problems with dependency resolution.

We want to install dependencies in a different travis phase than
building the package under test, so that travis can distinguish upstream
failures from local failures.  The dependencies include both HEAD_DEPS
and packages which are not dependencies of any HEAD_DEPS.

We used to invoke cabal once for the HEAD_DEPS, and once for the current
package with `--only-dependencies`.  This leads to diamond dependency
problems, which are often masked by cabal building the current package
with diagrams-* versions from Hackage, instead of the HEAD_DEPS.  For
example, cabal tries to rebuild `diagrams-core` with a different version
of `profunctors`, but doesn't know to pick diagrams-core HEAD.

More recently, we call `cabal install --only-dependencies` with both the
HEAD_DEPS and the current package.  This does seem to help with some
diamond dependency issues, but cabal gives up when one HEAD_DEP depends
on another.  For example `cabal install --only-dependencies
monoid-extras/ diagrams-core/ .` asks cabal to install `monoid-extras`
and not to install `monoid-extras`.

In the context of a cabal sandbox, cabal's solver behaves somewhat
differently.  It will only ever install one version of one package, and
we can register HEAD_DEPS without installing anything.  For example,
`cabal add-source diagrams-core` implies that cabal should not install
any version of `diagrams-core` except HEAD.  This should prevent both
problems outlined above.  We have only one command to install the
HEAD_DEPS and all dependencies, so cabal resolves all version
constraints together.