### PR TITLE
separate git_deps from before_install.sh

### DIFF
--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -9,17 +9,9 @@ sudo add-apt-repository -y ppa:hvr/ghc\
 	 echo "Installing Ubuntu packages: $UBUNTU_PKGS"
 	 sudo apt-get install $UBUNTU_PKGS
      fi\
-  && HEAD_BRANCH=$(python travis/scripts/head_branch.py)\
-  && for DEP in $HEAD_DEPS
-     do
-       echo "Cloning $DEP from github..."
-       git clone --quiet git://github.com/diagrams/$DEP.git
-       cd $DEP
-       if git branch -a |grep -x "  remotes/origin/${HEAD_BRANCH}" > /dev/null; then git checkout ${HEAD_BRANCH}; fi
-       cd ..
-     done
+  && travis/scripts/git_deps.sh
 
-  # Uncomment whenever hackage is down --- doesn't actually work
+ # Uncomment whenever hackage is down --- doesn't actually work
   # because travis does its own 'cabal update' before even calling our
   # scripts =(
 

--- a/scripts/git_deps.sh
+++ b/scripts/git_deps.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+HEAD_BRANCH=$(python travis/scripts/head_branch.py)\
+  && for DEP in $HEAD_DEPS
+     do
+       echo "Cloning $DEP from github..."
+       git clone --quiet git://github.com/diagrams/$DEP.git
+       cd $DEP
+       if git branch -a |grep -x "  remotes/origin/${HEAD_BRANCH}" > /dev/null; then git checkout ${HEAD_BRANCH}; fi
+       cd ..
+     done


### PR DESCRIPTION
Containerized builds on travis specify the PPA and GHC version in
travis.yml, instead of calling apt-get.  They still need to clone
HEAD_DEPS from git.

Useful for https://github.com/diagrams/diagrams-builder/pull/26