### PR TITLE
remove stale cabal config when installing cabal

### DIFF
--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -3,6 +3,7 @@
 # Use hvr's PPA of up-to-date GHC packages
 sudo add-apt-repository -y ppa:hvr/ghc\
   && sudo apt-get update\
+  && rm -f ~/.cabal/config\
   && sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER\
   && if ! [[ -z "$UBUNTU_PKGS" ]]
        then


### PR DESCRIPTION
This should hopefully fix "unrecognized stanza" errors due to cabal config file
format change, see e.g. https://travis-ci.org/diagrams/diagrams-rasterific/jobs/358030895

Compare https://github.com/haskell/cabal/issues/3467, the cabal config file format seems to have changed.

It might be cleaner to put this next to the call to `cabal update` in install.sh, but there's some commented code in `before_install.sh` that would break then.