### PR TITLE
catch http errors in github api branch lookup

### DIFF
--- a/scripts/head_branch.py
+++ b/scripts/head_branch.py
@@ -13,6 +13,10 @@ else:
         os.environ['TRAVIS_REPO_SLUG'],
         os.environ['TRAVIS_PULL_REQUEST'] )
     req = urllib.urlopen(url)
+    if req.getcode() < 200 or req.getcode() >= 300:
+        raise Exception(
+            "pull request lookup error: code {}: body {}".format(
+                req.getcode(), req.read()))
     j = json.load(req)
     # should we check here that the head is actually from the same
     # repo, not a fork?


### PR DESCRIPTION
I'm seeing some seemingly random travis failures related to pull requests on diagrams-rasterific, e.g. https://travis-ci.org/diagrams/diagrams-rasterific/jobs/406183439 failing with

```
Traceback (most recent call last):
  File "travis/scripts/head_branch.py", line 19, in <module>
    print(j['head']['ref'])
KeyError: 'head'
The command "./travis/scripts/before_install.sh" failed and exited with 1 during .
```

I suspect that the github API occasionally refuses the requests due to overload or something. At any rate this change should provide more helpful errors if that ever happens.
