### PR TITLE
Add 'v1-' prefix to cabal-3.0 commands

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,32 +1,32 @@
-$CABAL update\
+$CABAL ${V1}update\
   && if ! [[ -n $SKIP_TOOLS ]]
        then
-         $CABAL install alex happy cpphs -j$NUM_CPU
+         $CABAL ${V1}install alex happy cpphs -j$NUM_CPU
      fi\
   && if ! [[ $GHCVER == "head" || -n $SKIP_HADDOCK ]]
        then
-         $CABAL install $CABAL_CONSTRAINTS haddock -j$NUM_CPU
+         $CABAL ${V1}install $CABAL_CONSTRAINTS haddock -j$NUM_CPU
      fi\
   && if ! [[ -z "$EXTRA_DEPS_PRE" ]]
        then
          echo "============================================================"
          echo "Pre-installing extra dependencies: $EXTRA_DEPS_PRE"
-	 EXTRA_DEPS_PRE_INSTALL="$CABAL install $EXTRA_DEPS_PRE $CABAL_CONSTRAINTS -j$NUM_CPU"
+	 EXTRA_DEPS_PRE_INSTALL="$CABAL ${V1}install $EXTRA_DEPS_PRE $CABAL_CONSTRAINTS -j$NUM_CPU"
 	 echo $EXTRA_DEPS_PRE_INSTALL
 	 $EXTRA_DEPS_PRE_INSTALL --dry-run -v3
 	 $EXTRA_DEPS_PRE_INSTALL
      fi\
-  && $CABAL sandbox init\
+  && $CABAL ${V1}sandbox init\
   && if ! [[ -z "$HEAD_DEPS" ]]
        then
          echo "============================================================"
          echo "Registering HEAD dependencies: $HEAD_DEPS"
-         ADD_SOURCE="$CABAL sandbox add-source $HEAD_DEPS"
+         ADD_SOURCE="$CABAL ${V1}sandbox add-source $HEAD_DEPS"
          echo $ADD_SOURCE
          $ADD_SOURCE
      fi\
   && echo "Installing dependencies"\
-  && DEPS_INSTALL="$CABAL install  --enable-tests --enable-benchmarks --only-dependencies $CABAL_FLAGS $CABAL_CONSTRAINTS -j$NUM_CPU"\
+  && DEPS_INSTALL="$CABAL ${V1}install  --enable-tests --enable-benchmarks --only-dependencies $CABAL_FLAGS $CABAL_CONSTRAINTS -j$NUM_CPU"\
   && echo $DEPS_INSTALL\
   && $DEPS_INSTALL --dry-run -v3\
   && $DEPS_INSTALL\
@@ -34,7 +34,7 @@ $CABAL update\
        then
          echo "============================================================"
          echo "Installing extra dependencies: $EXTRA_DEPS"
-	 EXTRA_DEPS_INSTALL="$CABAL install $EXTRA_DEPS $CABAL_CONSTRAINTS -j$NUM_CPU"
+	 EXTRA_DEPS_INSTALL="$CABAL ${V1}install $EXTRA_DEPS $CABAL_CONSTRAINTS -j$NUM_CPU"
 	 echo $EXTRA_DEPS_INSTALL
 	 $EXTRA_DEPS_INSTALL --dry-run -v3
 	 $EXTRA_DEPS_INSTALL

--- a/scripts/script.sh
+++ b/scripts/script.sh
@@ -14,8 +14,8 @@ if [[ -n "$SKIP_TESTS" ]]
     TESTBUILD="$CABAL test"
 fi
 
-$CABAL configure --enable-tests --enable-benchmarks -v2 $CABAL_FLAGS\
-  && $CABAL build --ghc-options='-Wall -Werror -ddump-minimal-imports'\
+$CABAL ${V1}configure --enable-tests --enable-benchmarks -v2 $CABAL_FLAGS\
+  && $CABAL ${V1}build --ghc-options='-Wall -Werror -ddump-minimal-imports'\
   && $TESTBUILD\
   && $DOCBUILD\
   && $CABAL check\

--- a/scripts/set_env.sh
+++ b/scripts/set_env.sh
@@ -52,6 +52,18 @@ case "$GHCVER" in
   ;;
 esac
 
+# For cabal 3.* and onward, we need to prepend 'v1-' to cabal commands for
+# backwards compatibility with the build scripts.
+case "$CABALVER" in
+3.*)
+  echo "Detected CABALVER=3.*; prepending 'v1-' to cabal commands"
+  export V1='v1-'
+  ;;
+*)
+  export V1=''
+  ;;
+esac
+
 echo "Using cabal command: $CABAL"
 echo "  with constraints: $CABAL_CONSTRAINTS"
 echo "PATH: $PATH"


### PR DESCRIPTION
- For cabal 3.*, to obtain backwards-compatible behaviour, it is necessary to prepend 'v1-' to commands.

This is a possible (yet ever-so-hacky) fix for #9. I tested it on a custom Travis build of the `active` package here: https://travis-ci.org/lancelet/active/builds/594445644

Feel free to decline if this approach exceeds your hackiness budget. Alternatives include:
  - a more complete `cabal` wrapper which substitutes commands a bit more cleanly
  - switching to a different CI infrastructure like https://github.com/haskell-CI/haskell-ci
  - moving everything to `new-` commands and dropping support for older cabal versions (in CI)